### PR TITLE
Tierion::HashApi::Receipt#confirmation_status

### DIFF
--- a/lib/tierion/hash_api/receipt.rb
+++ b/lib/tierion/hash_api/receipt.rb
@@ -14,6 +14,17 @@ module Tierion
         @confs
       end
 
+      def confirmation_status(type)
+        anchors.each do |a|
+          if a['type'] == 'BTCOpReturn'
+            if a['sourceId'].present?
+              return btc_status(a['sourceId'])
+            end
+          end
+        end
+        nil
+      end
+
       # Checks the validity of the Merkle tree proof and
       # return true or false
       def valid?
@@ -73,8 +84,22 @@ module Tierion
         @confs
       end
 
-      # Confirm Bitcoin OP_RETURN anchor
-      def btc_op_return_confirmed?(source_id)
+      # The transaction could not be found (neither on the blockchain nor
+      # among the pending transactions)
+      NO_TRANSACTION = 0
+
+      # The tranasction is not valid, as it does not contain the expected OP_RETURN
+      INVALID_TRANSACTION = 1
+
+      # The transaction is valid (ie. contains the expected OP_RETURN).
+      # However, the transaction is not mined yet
+      OP_RETURN = 2
+
+      # The transaction is valid and mined
+      TRANSACTION_MINED = 3
+
+      # Return NO_TRANSACTION, INVALID_TRANSACTION, OP_RETURN or TRANSACTION_MINED
+      def btc_status(source_id)
         url = "https://blockchain.info/tx-index/#{source_id}?format=json"
 
         # op_return values begin with 0x6a (op_return code) &
@@ -83,15 +108,21 @@ module Tierion
 
         response = HTTParty.get(url)
 
-        if response.success? && response['out'].present?
-          has_op_return = response['out'].any? do |o|
-            o['script'].present? && o['script'] == op_return
-          end
+        return NO_TRANSACTION unless response.success?
 
-          return has_op_return
-        else
-          false
+        return INVALID_TRANSACTION unless response['out'].present?
+
+        return INVALID_TRANSACTION unless response['out'].any? do |o|
+          o['script'].present? && o['script'] == op_return
         end
+
+        return (response['block_height'].present? and response['block_height'] > 0) ? TRANSACTION_MINED : OP_RETURN
+      end
+
+
+      # Confirm Bitcoin OP_RETURN anchor
+      def btc_op_return_confirmed?(source_id)
+        btc_status(source_id) >= OP_RETURN
       end
     end
   end


### PR DESCRIPTION
`Tierion::HashApi::Receipt#confirmations` is clearly helpful but it returns a boolean per blockchain. In addition, it returns `true` when the BitCoin transaction is pending but not mined yet, which can be misleading coming from a method called `confirmations`.

`Tierion::HashApi::Receipt#confirmation_status` brings granularity by returning `NO_TRANSACTION`, `INVALID_TRANSACTION`, `OP_RETURN` or `TRANSACTION_MINED`.

I needed this method so I implemented it for me. Feel free to merge it or discard it.